### PR TITLE
It's just wrong to call it Singleton.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ You can see an up to date list of all ports in our [organization](https://github
 
 ## How to get started
 
-C++11 support for regex is still poor in the standard library, you will likely need boost_regex.
-Download / set that up, then try the example file. Once C++ standard supports <regex> decently it will be painless to switch. 
+In case you do not have C++11 compliant standard library you can still use boost.regex.
 
 ## Examples
 


### PR DESCRIPTION
I somewhat raged at the whole 'verbal expressions' thing and all that hype about it. I do not understand why you all make regexp even worse.

Anyway let's be right about few things in this port.

First of all C++11 support for regexps is good. Only few standard libraries do not implement this. But I can argue with this as for now. Also, you are calling "VerbEx()" a singleton which is not true. This is just object instantiation and all that verbal expression magic is just a method chaining through returning reference to this.

Please consider merging my fixes as I think many novice programmers could see this C++ port (through reading Verbal Expressions written in JavaScript through hackernews or something like that) and learn wrong about important aspects of this language.

Thanks.
