### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Basic usage of Verbal Expressions starts from the expression `verex()`. You can 
 auto expr = verex();
 ```
 
-##API
+## API
 
 ### Terms
 * .anything()


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
