### PR TITLE
Fixed C4458 warning on line 162 due to source having same name

### DIFF
--- a/verbalexpressions.hpp
+++ b/verbalexpressions.hpp
@@ -73,7 +73,7 @@ private:
         return (modifiers & CASEINSENSITIVE) ? veregex::regex::icase : static_cast<flag_type>(0);
     }
 
-    std::string reduce_lines(const std::string & value) const
+    static std::string reduce_lines(const std::string & value)
     {
         const std::size_t pos = value.find("\n");
 
@@ -159,10 +159,10 @@ public:
         return add("(?:[^" + value + "]+)");
     }
 
-    std::string replace(const std::string & source, const std::string & value)
+    std::string replace(const std::string & src, const std::string & value) const
     {
         return veregex::regex_replace(
-            source
+            src
           , veregex::regex(pattern, check_flags())
           , value
         );
@@ -318,11 +318,11 @@ public:
 
     verex & alt(const std::string & value)
     {
-        if (prefixes.find("(") == std::string::npos) {
+        if (prefixes.find('(') == std::string::npos) {
             prefixes += "(";
         }
 
-        if (suffixes.find(")") == std::string::npos) {
+        if (suffixes.find(')') == std::string::npos) {
             suffixes = ")" + suffixes;
         }
 
@@ -331,7 +331,7 @@ public:
         return then(value);
     }
 
-    bool test(const std::string & value)
+    bool test(const std::string & value) const
     {
         const std::string to_test = (modifiers & MULTILINE) ? value : reduce_lines(value);
 


### PR DESCRIPTION
Hi,
Thanks for this class, it's been very useful.

This PR fixes a C4458 warning on line 162 because it receives a "source" and has a class member var with same name. Personally I usually go with _ but in this case renaming it to src was the least distruptive change, I hope that's ok.

Also made a few functions const and replaced a couple string::find with the char equivalent.

![image](https://user-images.githubusercontent.com/423769/66704330-d2013700-ed12-11e9-9087-0ba77ac2fd2f.png)

Thanks.
